### PR TITLE
refactor(get_gomc_energy_data): modularized GOMC log parser and respective unit tests

### DIFF
--- a/namd_gomc-env.yml
+++ b/namd_gomc-env.yml
@@ -3,21 +3,31 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - sphinx
-  - ele
-  - nbsphinx
-  - lark-parser
-  - requests
-  - mock
-  - argparse
+  - pip
+  - numpy
   - pandas
   - scipy
-  - bumpy
-  - subprocess32
-  - json-c
-  - glob2
+  - matplotlib-base
+  - requests
+  - sphinx
+  - nbsphinx
+  - lark-parser
+  - mock
+  - ele
+  - mosdef-gomc
+  - mbuild
+  - foyer
+  - openmm
+  - netcdf4
+  - parmed
+  - mdtraj
+  - signac
+  - signac-flow
+  - rdkit
+  - pytest
+  - pytest-cov
+  - ipython
+  - jupyter_client
   - pip:
     - sphinx_rtd_theme
     - sphinxcontrib-svg2pdfconverter
-sphinx:
-  fail_on_warning: true

--- a/namd_gomc-env.yml
+++ b/namd_gomc-env.yml
@@ -14,6 +14,11 @@ dependencies:
   - lark-parser
   - mock
   - ele
+  - argparse
+  - bumpy
+  - subprocess32
+  - json-c
+  - glob2
   - mosdef-gomc
   - mbuild
   - foyer

--- a/py_mcmd_refactored/engines/gomc/parser.py
+++ b/py_mcmd_refactored/engines/gomc/parser.py
@@ -1,0 +1,51 @@
+import pandas as pd
+
+def parse_gomc_log(log_lines, box_number, current_step=0):
+    """Extract GOMC energy and box statistics into a DataFrame."""
+
+    e_titles, e_values = None, []
+    s_titles, s_values = None, []
+
+    get_e_titles = True
+    get_s_titles = True
+
+    for i, line in enumerate(log_lines):
+        if line.startswith("ETITLE:") and get_e_titles:
+            e_titles = line.split()
+            get_e_titles = False
+
+        elif line.startswith(f"ENER_{box_number}:"):
+            values = line.split()
+            parsed = []
+            for j, val in enumerate(values):
+                key = e_titles[j]
+                if key == "ETITLE:":
+                    parsed.append(val)
+                elif key == "STEP":
+                    parsed.append(int(val) + current_step)
+                else:
+                    parsed.append(float(val))  
+            e_values.append(parsed)
+
+        elif line.startswith("STITLE:") and get_s_titles:
+            s_titles = line.split()
+            get_s_titles = False
+
+        elif line.startswith(f"STAT_{box_number}:"):
+            values = line.split()
+            parsed = []
+            for j, val in enumerate(values):
+                key = s_titles[j]
+                if key == "STITLE:":
+                    parsed.append(val)
+                elif key == "STEP":
+                    parsed.append(int(val) + current_step)
+                else:
+                    parsed.append(float(val))
+            s_values.append(parsed)
+
+    if not e_values or e_titles is None:
+        raise ValueError("No energy data found in GOMC log.")
+
+    df = pd.DataFrame(e_values, columns=e_titles)
+    return df

--- a/py_mcmd_refactored/tests/engines/gomc/test_parser.py
+++ b/py_mcmd_refactored/tests/engines/gomc/test_parser.py
@@ -1,0 +1,13 @@
+import pandas as pd
+from py_mcmd_refactored.engines.gomc.parser import parse_gomc_log
+
+def test_parse_gomc_log_creates_dataframe():
+    sample_log = [
+        "ETITLE:  STEP TOTAL INTRA(B) INTRA(NB) INTER(LJ) LRC TOTAL_ELECT REAL RECIP SELF CORR ENTHALPY",
+        "ENER_0:   400 -862452.198853 0.0 0.0 138102.294455 0.0 -1.000550e+06 -952796.367113 1119.263862 -8.815010e+06 8.766013e+06 -279.134799"
+    ]
+    df = parse_gomc_log(sample_log, box_number=0, current_step=400)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert "TOTAL" in df.columns
+    assert abs(df.loc[0, "TOTAL"] + 862452.198853) < 1e-6


### PR DESCRIPTION
I was doing some initial setup and the `namd_gomc-env.yml` file contained a few typos and incompatible package specifications that prevented `conda` from creating the environment.

This also added in the packages seen in `requirement.txt` which I _presume_ to be the source of truth for dependencies. 

If this was intended or if I'm just misunderstanding something about the current config obviously I'll close this PR but I figured it might be helpful for anyone in the future trying to get setup since I was running into a few errors initiating the environment.